### PR TITLE
Refactor the R&D doc index

### DIFF
--- a/docs/client-development/index.md
+++ b/docs/client-development/index.md
@@ -1,9 +1,1 @@
-**RD / CD / CS review**
-
-On Thursdays every 2 weeks at 14:30
-
-Optional meeting
-
-Goal: the RD and CD teams will present the new features/improvements developed during the past sprint to the CS team.
-
-A Google Doc has been created (https://docs.google.com/document/d/11oJ0h7V1qBL2xdBlCJ_UCzw61LgvIKtE18fEcRpK4aY/edit#heading=h.7j35c0hb073c) where the RD and CD developers who want to present something can announce it, in a very short description and the CS team can write questions and add some inputs if they have checked/tested the app on the test server.
+# Client development team

--- a/docs/client-services/index.md
+++ b/docs/client-services/index.md
@@ -1,9 +1,1 @@
-**RD / CD / CS review**
-
-On Thursdays every 2 weeks at 14:30
-
-Optional meeting
-
-Goal: the RD and CD teams will present the new features/improvements developed during the past sprint to the CS team.
-
-A Google Doc has been created (https://docs.google.com/document/d/11oJ0h7V1qBL2xdBlCJ_UCzw61LgvIKtE18fEcRpK4aY/edit#heading=h.7j35c0hb073c) where the RD and CD developers who want to present something can announce it, in a very short description and the CS team can write questions and add some inputs if they have checked/tested the app on the test server.
+# Client Services documentation

--- a/docs/research-development/index.md
+++ b/docs/research-development/index.md
@@ -1,9 +1,12 @@
-**RD / CD / CS review**
+# Research & Development documentation
 
-On Thursdays every 2 weeks at 14:30
+## Team organisation
 
-Optional meeting
+The R&D team is developing the DaSCH Service Platform, including backend and frontend. They are divided in several [working groups](./working-group.md) where each group is working on one specific feature at a time.
 
-Goal: the RD and CD teams will present the new features/improvements developed during the past sprint to the CS team.
+The team is using Youtrack to manage their tasks.
+Get more info about the [Youtrack issue organisation](./youtrack-organisation.md)
 
-A Google Doc has been created (https://docs.google.com/document/d/11oJ0h7V1qBL2xdBlCJ_UCzw61LgvIKtE18fEcRpK4aY/edit#heading=h.7j35c0hb073c) where the RD and CD developers who want to present something can announce it, in a very short description and the CS team can write questions and add some inputs if they have checked/tested the app on the test server.
+## Roadmap
+
+See the [DSP roadmap on Youtrack.](https://dasch.myjetbrains.com/youtrack/articles/DSP-A-12/DSP-Roadmap)


### PR DESCRIPTION
The R&D doc index should be updated with the current information.

- some explanations about the team organisation with links to the other doc files
- link to the DSP roadmap